### PR TITLE
Use latest tag for installation

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -41,4 +41,6 @@ jobs:
         #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          latest: true
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 
 ```
-/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/v0.2.0/setup.sh)"
+/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch install instructions to the `latest` tag and set Release Drafter to mark releases as latest.
> 
> - **CI/GitHub Actions**:
>   - Configure `release-drafter.yml` to mark the drafted release as `latest` (`with.latest: true`).
> - **Docs**:
>   - Update install command in `README.md` to fetch from `refs/tags/latest` instead of a pinned version tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edf6f9195e03214754ffe3e92692e8916d8f3663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->