### PR TITLE
Fix default python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,3 @@
 ```
 /bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"
 ```
-

--- a/setup.sh
+++ b/setup.sh
@@ -28,22 +28,21 @@ if [[ $? -ne 0 ]]; then
     asdf set --home nodejs ${TARGET_DEFAULT_GLOBAL_NODE}
 fi
 
+# Install pnpm
+pnpm --help > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "Missing pnpm. Installing..."
+    npm install -g pnpm
+fi
+
 # Install python
-export TARGET_DEFAULT_GLOBAL_PYTHON=24.11.0
+export TARGET_DEFAULT_GLOBAL_PYTHON=3.13.9
 python --help > /dev/null 2>&1 && which python | grep asdf > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     echo "Missing python. Installing..."
     asdf plugin add python
     asdf install python ${TARGET_DEFAULT_GLOBAL_PYTHON}
     asdf set --home python ${TARGET_DEFAULT_GLOBAL_PYTHON}
-fi
-
-
-# Install pnpm
-pnpm --help > /dev/null 2>&1
-if [[ $? -ne 0 ]]; then
-    echo "Missing pnpm. Installing..."
-    npm install -g pnpm
 fi
 
 # Install GitHub CLI


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set default Python to 3.13.9 and move pnpm installation earlier in the setup script.
> 
> - **Setup script (`setup.sh`)**:
>   - **Python**: Set `TARGET_DEFAULT_GLOBAL_PYTHON` to `3.13.9`.
>   - **pnpm**: Ensure pnpm is installed; move installation before Python setup.
> - **Docs**:
>   - Minor README whitespace cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc0538aef3338b86a4e132b6a3f549e8b9f3d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->