### PR TITLE
Use a dedicated latest tagger

### DIFF
--- a/.github/latest-tagger.yml
+++ b/.github/latest-tagger.yml
@@ -1,1 +1,0 @@
-tag-template: 'latest'

--- a/.github/workflows/latest-tagger.yml
+++ b/.github/workflows/latest-tagger.yml
@@ -1,44 +1,6 @@
-name: Tag with Latest
-
-on:
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - main
-      - master
-
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
-
-permissions:
-  contents: read
-
-jobs:
-  update_release_draft:
-    permissions:
-      # write permission is required to create a github release
-      contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        with:
-          config-name: latest-tagger.yml
-          disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+- name: Tag Latest
+  uses: EndBug/latest-tag@latest
+  with:
+    # You can change the name of the tag or branch with this input.
+    # Default: 'latest'
+    ref: latest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace release-drafter with EndBug/latest-tag to tag `latest`, removing the old config.
> 
> - **CI (GitHub Actions)**:
>   - Replace release-drafter workflow with `EndBug/latest-tag@latest` to tag `latest` in `.github/workflows/latest-tagger.yml`.
>   - Remove obsolete config `.github/latest-tagger.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 650cbbac6c8c080fc3f7159fac15aadb8d38279f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->