### PR TITLE
Run tagger only on publish

### DIFF
--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Tag Latest
         uses: EndBug/latest-tag@latest
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update the tag workflow to run on release publish and add a checkout step before tagging.
> 
> - **CI/CD**:
>   - **Workflow `/.github/workflows/tag-latest.yml`**:
>     - Change trigger from `push` on `main/master` to `release: [published]`.
>     - Add `actions/checkout@v4` step before running `EndBug/latest-tag`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c491551dc4f5539b1cc132f55f7ac3c4625736a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->