### PR TITLE
Add 'setup' command to rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Northslope Machine Setup Script
 
 
+## Initial Setup
+
+Run the following command
+
 ```
 /bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"
 ```
+
+## After
+
+You can now use the command `setup` in your terminal to run the latest version of this script.

--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+function get_latest_version {
+    curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | jq -r '.tag_name' | sed 's/\s//g' | sed 's/\n//g'
+}
+
+
+northslope_setup_version=`cat ${HOME}/.northslope-setup-version`
+
+if [[ -z $1 ]]; then
+    echo "Usage: setup"
+    echo "   This command will run the northslope setup script for your machine."
+    echo "   Your Version  : ${northslope_setup_version}"
+    echo "   Latest Version: $(get_latest_version)"
+    exit 1
+fi
+
+/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,47 @@
 #!/bin/zsh
 
+function get_latest_version {
+    curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | jq -r '.tag_name' | sed 's/\s//g' | sed 's/\n//g'
+}
+
+NORTHSLOPE_SETUP_SCRIPT_PATH=${HOME}/.northslope-setup.sh
+NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH=${HOME}/.northslope-setup-version 
+
+# Add `setup` command to .zshrc
+cat ~/.zshrc | grep "alias setup=\"${NORTHSLOPE_SETUP_SCRIPT_PATH}\"" > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "alias setup=\"${NORTHSLOPE_SETUP_SCRIPT_PATH}\"" >> $HOME/.zshrc
+    alias setup="${NORTHSLOPE_SETUP_SCRIPT_PATH}"
+fi
+echo "Installed"
+
+
+IS_UPGRADING=0
+if [[ -e ${NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH} ]]; then
+    current_version=`cat ${NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH}`
+    if [[ "${current_version}" != "`get_latest_version`" ]]; then
+        echo "❌ Local 'setup' version is out of date."
+        IS_UPGRADING=1
+    else
+        echo "Version is up to date: ${current_version}"
+    fi
+fi
+
+if [[ ! -e ${NORTHSLOPE_SETUP_SCRIPT_PATH} || ! -e ${NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH} || ${IS_UPGRADING} -eq 1 ]]; then
+    if [ ${IS_UPGRADING} -eq 0 ]; then
+        # Show only if we are not upgrading
+        echo "‼ Missing '`basename ${NORTHSLOPE_SETUP_SCRIPT_PATH}`' script. Installing..."
+    else
+        echo "‼ Upgrading '`basename ${NORTHSLOPE_SETUP_SCRIPT_PATH}`' script..."
+    fi
+    curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/northslope-setup.sh > ${NORTHSLOPE_SETUP_SCRIPT_PATH}
+    get_latest_version > $NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH
+else
+    echo "`basename ${NORTHSLOPE_SETUP_SCRIPT_PATH}` is ok"
+fi
+
+chmod +x ${NORTHSLOPE_SETUP_SCRIPT_PATH}
+
 # Install Brew
 cat ~/.zshrc | grep "brew shellenv" > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an installable `setup` command that bootstraps/updates a versioned local script and provisions core dev tools via Homebrew/asdf; updates README with quickstart.
> 
> - **CLI & Bootstrap**:
>   - Add `northslope-setup.sh` that fetches and runs the latest `setup.sh`, with version display.
>   - Expand `setup.sh` to:
>     - Create `alias setup` in `.zshrc` pointing to `~/.northslope-setup.sh`.
>     - Install or upgrade `~/.northslope-setup.sh` and store version in `~/.northslope-setup-version` using GitHub releases.
>     - Mark the script executable and confirm status.
> - **Toolchain Installation**:
>   - Ensure Homebrew is installed and initialized.
>   - Install `asdf` and configure PATH.
>   - Install and set global versions for `nodejs` (`24.11.0`) and `python` (`3.13.9`) via `asdf`.
>   - Install `pnpm` via npm and `gh` via brew; run `asdf reshim`.
> - **Docs**:
>   - Update `README.md` with initial setup command and note on using the `setup` command thereafter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e273bcc4f823ddd23ce63527779ce1363531b456. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->