### PR TITLE
Bugfix/fix bad setup guard

### DIFF
--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -4,6 +4,12 @@ function get_latest_version {
     curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | jq -r '.tag_name' | sed 's/\s//g' | sed 's/\n//g'
 }
 
+function print_usage {
+    echo "Usage: setup"
+    echo "   This command will run the northslope setup script for your machine."
+    echo "   Your Version  : ${northslope_setup_version}"
+    echo "   Latest Version: $(get_latest_version)"
+}
 
 northslope_setup_version=`cat ${HOME}/.northslope-setup-version`
 
@@ -11,10 +17,7 @@ if [[ ! -z $1 ]]; then
     # Prints the help message if any
     # arguments are passed. In the future,
     # we can check to make sure it's a '--help'
-    echo "Usage: setup"
-    echo "   This command will run the northslope setup script for your machine."
-    echo "   Your Version  : ${northslope_setup_version}"
-    echo "   Latest Version: $(get_latest_version)"
+    print_usage
     exit 1
 fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Show usage only when arguments are provided by introducing `print_usage` and adjusting the arg check; default runs remote setup.
> 
> - **Setup Script (`northslope-setup.sh`)**:
>   - Add `print_usage` function to display usage, current version, and latest version.
>   - Reverse argument guard to show usage only when any args are passed (`[[ ! -z $1 ]]`), otherwise proceed.
>   - Keep execution of remote installer unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dec1fb21f15ecc496562c3f52079cd7e4ef0e527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->