### PR TITLE
Address missing latest tag

### DIFF
--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   tag_latest:
@@ -20,4 +20,5 @@ jobs:
         uses: EndBug/latest-tag@latest
         with:
           ref: latest
+          force-branch: true
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update the tag-latest GitHub Actions workflow to grant write permissions and force branch creation when tagging latest.
> 
> - **CI**:
>   - Update `.github/workflows/tag-latest.yml`:
>     - Set top-level `permissions` to `contents: write`.
>     - Add `force-branch: true` to `EndBug/latest-tag` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eef501c8258ef6edd8d7f810bb1cf14f54b6195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->