### PR TITLE
Use latest branch not tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 Run the following command
 
 ```
-/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"
+/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh)"
 ```
 
 ## After
 
 You can now use the command `setup` in your terminal to run the latest version of this script.
+
+```
+setup
+```

--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -21,4 +21,4 @@ if [[ ! -z $1 ]]; then
     exit 1
 fi
 
-/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/setup.sh)"
+/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh)"

--- a/setup.sh
+++ b/setup.sh
@@ -88,7 +88,7 @@ if [[ ! -e ${NORTHSLOPE_SETUP_SCRIPT_PATH} || ! -e ${NORTHSLOPE_SETUP_SCRIPT_VER
     else
         echo "Upgrading ${TOOL}..."
     fi
-    curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/tags/latest/northslope-setup.sh > ${NORTHSLOPE_SETUP_SCRIPT_PATH}
+    curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/northslope-setup.sh > ${NORTHSLOPE_SETUP_SCRIPT_PATH}
     get_latest_version > $NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH
 fi
 print_installed_msg ${TOOL}


### PR DESCRIPTION
The `latest-tag` workflow action does not create the tag, but creates a branch labeled `latest`. Not the best flow, but good enough for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches script downloads to the latest branch and adds a README snippet showing `setup` usage.
> 
> - **Setup scripts**:
>   - Update fetch URLs in `README.md`, `northslope-setup.sh`, and `setup.sh` to use `refs/heads/latest` instead of `refs/tags/latest` for pulling `setup.sh`/`northslope-setup.sh`.
> - **Docs**:
>   - Add example usage block showing the `setup` command invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d18d6184162ed8bdf668400b6f4bf17908332bcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->