### PR TITLE
Add password warning for brew

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -108,6 +108,8 @@ if [[ $? -ne 0 ]]; then
     echo "  ⚠️ your computer. Please be prepared.   ⚠️"
     echo "  Press Enter once you have your computer password..."
     read
+    echo "  ⚠️ The following command can take upwards of 10-20 minutes, depending on your internet connection."
+    echo "  ⚠️ Please be patient, but if you need to cancel at any time, press Ctrl+C"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> $HOME/.zshrc
     eval $(/opt/homebrew/bin/brew shellenv)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds user prompts and warnings in setup.sh before installing Homebrew, including password notice, expected duration, and a pause for confirmation.
> 
> - **Setup (`setup.sh`)**:
>   - **Homebrew installation**:
>     - Add user-facing warnings about potential password prompt and long install time.
>     - Prompt user to press Enter before proceeding and note how to cancel (Ctrl+C).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03dcc992cbd8bc7efc270da6fb836a997e4fd70b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->