### PR TITLE
Migrate setup and versions to folder

### DIFF
--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -11,7 +11,7 @@ function print_usage {
     echo "   Latest Version: $(get_latest_version)"
 }
 
-northslope_setup_version=`cat ${HOME}/.northslope-setup-version`
+northslope_setup_version=`cat ${HOME}/.northslope/setup-version`
 
 if [[ ! -z $1 ]]; then
     # Prints the help message if any

--- a/setup.sh
+++ b/setup.sh
@@ -46,8 +46,19 @@ function asdf_install_and_set {
     print_installed_msg ${tool}
 }
 
-NORTHSLOPE_SETUP_SCRIPT_PATH=${HOME}/.northslope-setup.sh
-NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH=${HOME}/.northslope-setup-version 
+NORTHSLOPE_DIR=${HOME}/.northslope
+mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
+
+NORTHSLOPE_SETUP_SCRIPT_PATH=${NORTHSLOPE_DIR}/northslope-setup.sh
+NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH=${NORTHSLOPE_DIR}/setup-version
+
+# Remove old versions of script and cache
+for f in ${HOME}/.northslope*; do
+    if [[ -d ${f} ]]; then
+        continue
+    fi
+    rm ${f}
+done
 
 # Add `setup` command to .zshrc
 TOOL=setup
@@ -55,8 +66,21 @@ print_check_msg ${TOOL}
 cat ~/.zshrc | grep "alias setup=\"${NORTHSLOPE_SETUP_SCRIPT_PATH}\"" > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     print_missing_msg ${TOOL}
-    echo "alias setup=\"${NORTHSLOPE_SETUP_SCRIPT_PATH}\"" >> $HOME/.zshrc
+    # Remove old setup alias
+    TEMP_ZSHRC=${NORTHSLOPE_DIR}/temp-zshrc
+    cat ${HOME}/.zshrc | fgrep -v "alias setup=\"" | fgrep -v "# Added by Northslope" > ${TEMP_ZSHRC}
+    # Add the new alias
+    echo "" >> ${TEMP_ZSHRC}
+    echo "# Added by Northslope" >> ${TEMP_ZSHRC}
+    echo "alias setup=\"${NORTHSLOPE_SETUP_SCRIPT_PATH}\"" >> ${TEMP_ZSHRC}
+    # Backup the .zshrc file
+    cp ${HOME}/.zshrc ${HOME}/.zshrc.bak
+    # Over write the .zshrc
+    # cat used here in case .zshrc is symlinked
+    cat ${TEMP_ZSHRC} > ${HOME}/.zshrc
+    rm ${TEMP_ZSHRC}
     alias setup="${NORTHSLOPE_SETUP_SCRIPT_PATH}"
+    chmod +x ${NORTHSLOPE_SETUP_SCRIPT_PATH}
 fi
 print_installed_msg ${TOOL}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates setup script/version into `~/.northslope`, cleans up legacy files, and hardens zsh alias installation with backup and permissions.
> 
> - **Setup storage**:
>   - Introduces `NORTHSLOPE_DIR` at `~/.northslope` and moves `northslope-setup.sh` and `setup-version` into this folder.
>   - Updates version read path in `northslope-setup.sh` to `~/.northslope/setup-version`.
>   - Adds cleanup to remove legacy `~/.northslope*` files (non-directories).
> - **Shell integration**:
>   - Replaces naive alias append with a safer flow: strips old `setup` alias lines and markers, writes a tagged alias to a temp file, backs up and overwrites `~/.zshrc`.
>   - Ensures `northslope-setup.sh` is executable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 613e4ba34fcde62762c3d3730c9c29ef1892faf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->