### PR TITLE
Install osdk-cli

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -215,7 +215,6 @@ if [[ ! -e ${LOCAL_OSDK_CLI_DIR} ]]; then
     cd ${LOCAL_OSDK_CLI_DIR}
     # TODO: Switch to origin/latest once the bugfix is put in place
     git checkout origin/bugfix/allow-npm-install-from-clone
-    git pull origin
     cd -
 fi
 print_installed_msg ${TOOL}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds osdk-cli clone/install flow and failure tracking, updating setup completion messaging accordingly.
> 
> - **Setup enhancements**:
>   - **osdk-cli**:
>     - Clone `northslopetech/osdk-cli` into `~/.northslope/packages/osdk-cli` (checks out `origin/bugfix/allow-npm-install-from-clone`).
>     - Install globally via `npm -g install <local path>` if `osdk-cli` not present.
>   - **Failure handling**:
>     - Introduce `DID_FAIL` flag and `print_failed_install_msg` to track/report failed installs.
>     - Final output now conditionally prints success or failure with guidance.
>   - Create `~/.northslope/packages` directory to house cloned packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 466de215fec7a72a312373de7139e2a45383e881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->