### PR TITLE
Add working osdk installer

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -226,6 +226,7 @@ osdk-cli --help > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     print_missing_msg ${TOOL}
     cd ${LOCAL_OSDK_CLI_DIR}
+    pnpm install
     pnpm build
     npm link
     cd -


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends `setup.sh` to clone, build, and link `osdk-cli` from `northslopetech/osdk-cli` and ensure it’s available on PATH.
> 
> - **Setup script (`setup.sh`)**:
>   - **osdk-cli installation**:
>     - Creates `~/.northslope/packages` and clones `northslopetech/osdk-cli` into `packages/osdk-cli`.
>     - Checks out `origin/bugfix/allow-npm-install-from-clone`.
>     - Runs `pnpm install`, `pnpm build`, and `npm link`; verifies `osdk-cli --help`.
>   - **Auth prerequisite**: Ensures `gh auth` before cloning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd55adf321feb2aaebed12ae5a2c813be070e441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->