### PR TITLE
Add initial posthog started event

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,8 @@ function get_latest_version {
     curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | jq -r '.tag_name' | sed 's/\s//g' | sed 's/\n//g'
 }
 
+LATEST_SCRIPT_VERSION=`get_latest_version`
+
 function print_check_msg {
     local tool=$1
     printf "Checking '${tool}'... "
@@ -72,7 +74,8 @@ function emit_setup_started_event {
                 "distinct_id": "'"${USER}"'",
                 "timezone_offset": "'"${current_timezone}"'",
                 "session_key": "'"${session_key}"'",
-                "timestamp": "'"`get_timestamp`"'"
+                "timestamp": "'"`get_timestamp`"'",
+                "latest_version": "'"${LATEST_SCRIPT_VERSION}"'"
             }
         }' > /dev/null 2>&1
 }
@@ -87,7 +90,8 @@ function emit_setup_finished_event {
                 "distinct_id": "'"${USER}"'",
                 "timezone_offset": "'"${current_timezone}"'",
                 "session_key": "'"${session_key}"'",
-                "timestamp": "'"`get_timestamp`"'"
+                "timestamp": "'"`get_timestamp`"'",
+                "latest_version": "'"${LATEST_SCRIPT_VERSION}"'"
             }
         }' > /dev/null 2>&1
 }
@@ -137,7 +141,7 @@ print_check_msg "setup version"
 IS_UPGRADING=0
 if [[ -e ${NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH} ]]; then
     current_version=`cat ${NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH}`
-    if [[ "${current_version}" != "`get_latest_version`" ]]; then
+    if [[ "${current_version}" != "${LATEST_SCRIPT_VERSION}" ]]; then
         echo "Local 'setup' version is out of date. 🚫"
         IS_UPGRADING=1
     else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Emits PostHog events at setup start/finish with metadata and uses a cached latest version for checks.
> 
> - **Telemetry**:
>   - Add `emit_setup_started_event` and `emit_setup_finished_event` to POST to PostHog with `distinct_id`, `timezone_offset`, `session_key`, `timestamp`, and `latest_version`.
>   - Fire events asynchronously at script start and end (`emit_setup_started_event &`, `emit_setup_finished_event &`).
> - **Utilities**:
>   - Add `get_timestamp` helper; generate `session_key`, `current_timezone`, and set `POSTHOG_KEY`.
> - **Versioning**:
>   - Introduce `LATEST_SCRIPT_VERSION` via `get_latest_version` and use it in version comparison and telemetry payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c31ef9898836a6e6c968a2a444be70a634cfc6f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->