### PR TITLE
Install OSDK with frozen lockfile

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -226,7 +226,7 @@ if [[ $? -ne 0 ]]; then
     git fetch --all
     git checkout origin/latest
     rm -rf ${LOCAL_OSDK_CLI_DIR}/node_modules > /dev/null 2>&1
-    pnpm install
+    pnpm install --frozen-lockfile
     pnpm build
     npm link
     cd -


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches osdk-cli installation to use `pnpm install --frozen-lockfile` in `setup.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d63e085d4120fd4e9a1e83f8cd2cc68bf58d534. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->