### PR TITLE
Add posthog env codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.envrc
+
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,osx,python,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,osx,python,node
 
@@ -148,7 +150,8 @@ dist
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/setup.sh
+++ b/setup.sh
@@ -54,6 +54,50 @@ function asdf_install_and_set {
     print_installed_msg ${tool}
 }
 
+function get_timestamp {
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+session_key="`date +%s`-$(( ( $RANDOM % 100 ) + 1 ))"
+POSTHOG_KEY=phc_Me99GOmroO6r5TiJwJoD3VpSoBr6JbWk3lo9rrLkEyQ
+current_timezone=`date "+%z"`
+
+function emit_setup_started_event {
+    curl --silent -XPOST https://us.i.posthog.com/capture/ \
+        --header "Content-Type: application/json" \
+        --data '{
+            "api_key": "'"${POSTHOG_KEY}"'",
+            "event": "setup:started",
+            "properties": {
+                "distinct_id": "'"${USER}"'",
+                "timezone_offset": "'"${current_timezone}"'",
+                "session_key": "'"${session_key}"'",
+                "timestamp": "'"`get_timestamp`"'",
+                "latest_version": "'"${LATEST_SCRIPT_VERSION}"'",
+                "env": "'"${POSTHOG_ENV:-prod}"'"
+            }
+        }' > /dev/null 2>&1
+}
+
+function emit_setup_finished_event {
+    curl --silent -XPOST https://us.i.posthog.com/capture/ \
+        --header "Content-Type: application/json" \
+        --data '{
+            "api_key": "'"${POSTHOG_KEY}"'",
+            "event": "setup:finished",
+            "properties": {
+                "distinct_id": "'"${USER}"'",
+                "timezone_offset": "'"${current_timezone}"'",
+                "session_key": "'"${session_key}"'",
+                "timestamp": "'"`get_timestamp`"'",
+                "latest_version": "'"${LATEST_SCRIPT_VERSION}"'",
+                "env": "'"${POSTHOG_ENV:-prod}"'"
+            }
+        }' > /dev/null 2>&1
+}
+
+emit_setup_started_event &
+
 NORTHSLOPE_DIR=${HOME}/.northslope
 mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
 


### PR DESCRIPTION
Ensures we can separate test events from real ones

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds PostHog capture of setup start/finish events (with env codes) to `setup.sh` and ignores `.envrc`.
> 
> - **Setup script (`setup.sh`)**:
>   - Add PostHog telemetry for `setup:started` and `setup:finished` events via `curl` to `https://us.i.posthog.com/capture/`.
>     - New helpers and vars: `get_timestamp`, `session_key`, `POSTHOG_KEY`, `current_timezone`, `POSTHOG_ENV` (defaults to `prod`).
>     - Sends properties: `distinct_id`, `timezone_offset`, `session_key`, `timestamp`, `latest_version`, `env`.
>     - Fire `emit_setup_started_event` in background at startup.
> - **Git ignore**:
>   - Ignore `.envrc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7813efb92aab0a4f56dd95f7965d50f6808123f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->