### PR TITLE
Install cli if wrong path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -266,7 +266,7 @@ osdk-cli --help > /dev/null 2>&1
 missing_cli=$?
 which osdk-cli | grep ".asdf" > /dev/null 2>&1
 wrong_cli=$?
-if [[ ${install_cli} -ne 0 || ${wrong_cli} -ne 0 ]]; then
+if [[ ${missing_cli} -ne 0 || ${wrong_cli} -ne 0 ]]; then
     print_missing_msg ${TOOL}
     cd ${LOCAL_OSDK_CLI_DIR}
     git checkout main


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure `osdk-cli` is (re)installed if absent or not sourced from asdf-managed path.
> 
> - **Setup Script (`setup.sh`)**:
>   - **`osdk-cli` install check**:
>     - Capture `missing_cli` from `osdk-cli --help` and detect non-asdf binary via `which osdk-cli | grep ".asdf"`.
>     - Reinstall/link `osdk-cli` when missing or when the resolved binary is not from asdf shims.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2c79dec848cfb4bfe31dc14e514af2593a140a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->