### PR TITLE
Add missing jq

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -214,6 +214,7 @@ asdf_tools=(
     python__3.13.9
     github-cli__2.83.0
     uv__0.9.7
+    jq__1.8.1
 )
 
 for asdf_tool in ${asdf_tools[@]}; do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `jq` (v1.8.1) to the asdf-managed tools in `setup.sh`.
> 
> - **Setup (`setup.sh`)**:
>   - Add `jq__1.8.1` to `asdf_tools` for automatic install via asdf.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3433a39fbfb262491009aaa76459c08641964a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->