### PR TITLE
Force asdf to always export on path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -203,9 +203,9 @@ if [[ $? -ne 0 ]]; then
     brew install asdf
     # TODO: Can we force asdf to always override the brew path?
     echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.zshrc
-    export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 fi
 print_installed_msg ${TOOL}
+export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # Install all of the following tools using asdf
 asdf_tools=(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure ASDF shims are always added to PATH during setup, not only on first install.
> 
> - **setup.sh**
>   - Always export ASDF shims to PATH by moving `export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"` outside the `asdf` install check.
>   - Keeps `.zshrc` update to persist the PATH change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5af2ff6c6a15bf6933f5ca594eeb5c4ee9880a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->