### PR TITLE
Check .zshrc for asdf

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -213,6 +213,7 @@ if [[ $? -ne 0 ]]; then
     print_missing_msg ${TOOL}
     echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.zshrc
 fi
+print_installed_msg ${TOOL}
 
 # Install all of the following tools using asdf
 asdf_tools=(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a check to append the asdf shims PATH to ~/.zshrc if missing, replacing the previous unconditional add.
> 
> - **setup.sh**:
>   - **asdf PATH handling**:
>     - Adds a check to ensure `export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"` exists in `~/.zshrc`; appends it if missing.
>     - Removes the earlier unconditional append during asdf install.
>     - Retains runtime export of the asdf shims PATH for the current session.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a44033fe6abad418cf520d63faf399edaff2dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->