### PR TITLE
Add setup for git config

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -194,6 +194,42 @@ if [[ $? -ne 0 ]]; then
 fi
 print_installed_msg ${TOOL}
 
+# Check for git config name
+TOOL="git config name"
+print_check_msg ${TOOL}
+git config --global user.name > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    print_missing_msg ${TOOL}
+    echo "What is your full name?"
+    echo "ex. Tam Nguyen"
+    read git_name
+    git config --global user.name "${git_name}"
+fi
+print_installed_msg ${TOOL}
+
+# Check for git config email
+TOOL="git config email"
+print_check_msg ${TOOL}
+git config --global user.email > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    print_missing_msg ${TOOL}
+    echo "What is your email address?"
+    echo "ex. test@northslopetech.com"
+    read git_email
+    git config --global user.email "${git_email}"
+fi
+print_installed_msg ${TOOL}
+
+# Check for git config push.autoSetupRemote
+TOOL="git config push.autoSetupRemote"
+print_check_msg ${TOOL}
+git config --global push.autoSetupRemote | grep "true" > /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    print_missing_msg ${TOOL}
+    git config --global push.autoSetupRemote true
+fi
+print_installed_msg ${TOOL}
+
 # Install asdf
 TOOL=asdf
 print_check_msg ${TOOL}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds prompts to set global Git user.name and user.email, and enables push.autoSetupRemote=true in setup.sh.
> 
> - **Setup script (`setup.sh`)**:
>   - Add interactive checks/prompts to set global `git config user.name` and `git config user.email` if unset.
>   - Ensure `git config push.autoSetupRemote` is set to `true` by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2990a95b57e3fd6026c56d7bd62d88cc00b1267e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->