### PR TITLE
Add cursor install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -230,6 +230,15 @@ if [[ $? -ne 0 ]]; then
 fi
 print_installed_msg ${TOOL}
 
+# Install Cursor
+TOOL=cursor
+print_check_msg ${TOOL}
+if [[ ! -d "/Applications/Cursor.app" ]]; then
+    print_missing_msg ${TOOL}
+    brew install --cask cursor
+fi
+print_installed_msg ${TOOL}
+
 # Install asdf
 TOOL=asdf
 print_check_msg ${TOOL}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Cursor editor installation to `setup.sh` using Homebrew cask when not already installed.
> 
> - **Setup script (`setup.sh`)**:
>   - **New installation step**: Installs `cursor` via `brew install --cask cursor` if `/Applications/Cursor.app` is missing, with corresponding check/missing/installed messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e6ce223386d65c6b447a23cc05237608876cd90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->