### PR TITLE
install osdk-cli from npm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -256,10 +256,8 @@ print_check_msg ${TOOL}
 osdk-cli --help > /dev/null 2>&1
 missing_cli=$?
 which osdk-cli | grep ".asdf" > /dev/null 2>&1
-
-install_status=0
-
 wrong_cli=$?
+install_status=0
 if [[ ${missing_cli} -ne 0 || ${wrong_cli} -ne 0 ]]; then
     print_missing_msg ${TOOL}
     npm install -g @northslopetech/osdk-cli


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches osdk-cli installation to the published npm package and removes the local clone/build flow, with simple install status handling.
> 
> - **setup.sh**:
>   - **osdk-cli install**:
>     - Replace local clone/build workflow with `npm install -g @northslopetech/osdk-cli`.
>     - Add `install_status` handling to gate success/failure messaging.
>   - Minor cleanup: remove package cloning block related to `osdk-cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b449c7a225093354d2edbe767b6cb466f3e1e85d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->