### PR TITLE
unconditionally run npm install osdk-cli

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -252,21 +252,14 @@ echo "'gh auth' Authorized ✅"
 
 # Installing osdk-cli
 TOOL="osdk-cli"
-print_check_msg ${TOOL}
-osdk-cli --help > /dev/null 2>&1
-missing_cli=$?
-which osdk-cli | grep ".asdf" > /dev/null 2>&1
-wrong_cli=$?
+print_check_msg "${TOOL}"
 install_status=0
-if [[ ${missing_cli} -ne 0 || ${wrong_cli} -ne 0 ]]; then
-    print_missing_msg ${TOOL}
-    npm install -g @northslopetech/osdk-cli
-    install_status=$?
-fi
+npm install -g @northslopetech/osdk-cli >/dev/null 2>&1
+install_status=$?
 if [[ ${install_status} -ne 0 ]]; then
-    print_failed_install_msg ${TOOL}
+    print_failed_install_msg "${TOOL}"
 else
-    print_installed_msg ${TOOL}
+    print_installed_msg "${TOOL}"
 fi
 
 


### PR DESCRIPTION
@tamsanh LMK what you think of this

Changed the script so that it doesn't check for whether osdk-cli is already installed (or if it's installed with asdf). Just unconditionally running `npm install osdk-cli`, which for users who don't have osdk-cli installed will install it, and for users who already have it installed, will install the latest version

Let me know if you want the asdf check though, I can add it back in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `setup.sh` to unconditionally run `npm install -g @northslopetech/osdk-cli`, removing prior presence/asdf checks and suppressing install output.
> 
> - **Setup Script (`setup.sh`)**:
>   - Unconditionally installs `@northslopetech/osdk-cli` via `npm install -g` (output suppressed), removing previous presence/asdf checks.
>   - Normalizes status messaging by quoting `TOOL` in `print_*` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88aed332c4737d9a13327e815b98e99ceb146f6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->