### PR TITLE
Fix bad zshrc check for asdf

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -279,9 +279,9 @@ print_installed_msg ${TOOL}
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # Check asdf is in zshrc
-cat ~/.zshrc | grep 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' > /dev/null 2>&1
 TOOL="asdf in .zshrc"
 print_check_msg ${TOOL}
+cat ~/.zshrc | grep 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     print_missing_msg ${TOOL}
     echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.zshrc


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorders the `.zshrc` grep for the `asdf` PATH to occur after `print_check_msg` in `setup.sh`.
> 
> - **Setup (`setup.sh`)**
>   - Repositions the `cat ~/.zshrc | grep 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"'` to run after `print_check_msg` within the "asdf in .zshrc" check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93684c789de8218f1502fbdf78eb8b650307c827. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->