### PR TITLE
Add missing tool check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ function asdf_install_and_set {
     # No-op if command is installed
     asdf install ${tool} ${version} > /dev/null 2>&1
 
-    check_home_version_set
+    check_home_version_set ${tool}
     if [[ $? -ne 0 ]]; then
         # If a home version is not chosen
         # we choose the default version


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix `setup.sh` to pass the tool name to `check_home_version_set` during asdf installs.
> 
> - **Setup script (`setup.sh`)**:
>   - Fix `asdf_install_and_set`: call `check_home_version_set` with the `tool` argument to correctly detect whether a home version is already set before invoking `asdf set --home`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 223e7c443d8a40a5f83156f7a5999f0ad125a433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->