### PR TITLE
Refactor/organize script sections

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,18 +1,6 @@
 #!/bin/zsh
 
-#==============================================================================
-# CONFIGURATION & CONSTANTS
-#==============================================================================
-
 DID_FAIL=0
-session_key="`date +%s`-$(( ( $RANDOM % 100 ) + 1 ))"
-current_timezone=`date "+%z"`
-
-POSTHOG_KEY=phc_Me99GOmroO6r5TiJwJoD3VpSoBr6JbWk3lo9rrLkEyQ
-
-NORTHSLOPE_DIR=${HOME}/.northslope
-NORTHSLOPE_SETUP_SCRIPT_PATH=${NORTHSLOPE_DIR}/northslope-setup.sh
-NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH=${NORTHSLOPE_DIR}/setup-version
 
 #==============================================================================
 # UTILITY FUNCTIONS
@@ -51,6 +39,9 @@ function print_missing_msg {
 # ANALYTICS FUNCTIONS
 #==============================================================================
 
+POSTHOG_KEY=phc_Me99GOmroO6r5TiJwJoD3VpSoBr6JbWk3lo9rrLkEyQ
+session_key="`date +%s`-$(( ( $RANDOM % 100 ) + 1 ))"
+current_timezone=`date "+%z"`
 function emit_setup_started_event {
     local LATEST_SCRIPT_VERSION=`get_latest_version`
     curl --silent -XPOST https://us.i.posthog.com/capture/ \
@@ -126,6 +117,7 @@ function asdf_install_and_set {
 # Initialization
 #------------------------------------------------------------------------------
 
+NORTHSLOPE_DIR=${HOME}/.northslope
 emit_setup_started_event &
 
 mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
@@ -141,6 +133,9 @@ done
 #------------------------------------------------------------------------------
 # Setup Command Installation
 #------------------------------------------------------------------------------
+
+NORTHSLOPE_SETUP_SCRIPT_PATH=${NORTHSLOPE_DIR}/northslope-setup.sh
+NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH=${NORTHSLOPE_DIR}/setup-version
 
 # Add `setup` command to .zshrc
 TOOL=setup


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorganizes setup.sh into clearly sectioned phases, centralizes helper/analytics functions, moves and deduplicates asdf setup, and streamlines setup command versioning and aliasing.
> 
> - **Refactor setup.sh structure**
>   - Introduces clear section banners and reorganizes flow: initialization → setup command installation → package managers → git config → dev tools → languages/tools via `asdf` → auth → Northslope tools → finalization.
>   - Centralizes utility, analytics, and installation helper functions (`get_timestamp`, `check_home_version_set`, `asdf_install_and_set`) at top.
> - **Analytics**
>   - Groups analytics vars/functions; defines `session_key`/`current_timezone` early; backgrounds `emit_setup_started_event` and `emit_setup_finished_event` at start/end.
> - **asdf setup**
>   - Moves `asdf` installation earlier under package managers; ensures PATH/shims export and `.zshrc` entry; removes duplicate `asdf` install block.
> - **Setup command management**
>   - Clarifies version check and conditional download/upgrade of `northslope-setup.sh`; keeps aliasing in `.zshrc`.
> - **No functional additions**
>   - Keeps existing tool installs (brew, cursor, claude, asdf-managed tools, gh auth, osdk-cli) with same versions; primarily reordering/organization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fbc72e523d694a4085ad9010177b044162d0c22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->