### PR TITLE
Feature/improve failure handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -136,9 +136,9 @@ function emit_failure_event {
     local timestamp=$4
     local LATEST_SCRIPT_VERSION=`get_latest_version`
 
-    # Escape error message for JSON
-    local escaped_error_msg=$(echo "${error_msg}" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g' | tr -d '\n' | tr -d '\r')
-    local escaped_tool=$(echo "${tool}" | sed 's/"/\\"/g')
+    # Escape error message for JSON (backslashes first, then quotes)
+    local escaped_error_msg=$(echo "${error_msg}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | tr -d '\n' | tr -d '\r')
+    local escaped_tool=$(echo "${tool}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
 
     # Build exception list
     local exception_list="[{\"type\":\"SetupFailure:${escaped_tool}\",\"value\":\"${escaped_error_msg}\",\"mechanism\":{\"type\":\"shell_script\",\"handled\":false},\"module\":\"${escaped_tool}\"}]"
@@ -205,11 +205,11 @@ function emit_setup_finished_event {
     local tools_json="{"
     local sep=""
     for i in {1..${#TOOL_NAMES[@]}}; do
-        # Escape strings for JSON
-        local escaped_name=$(echo "${TOOL_NAMES[$i]}" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g')
-        local escaped_msg=$(echo "${TOOL_MESSAGES[$i]}" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g' | tr -d '\n' | tr -d '\r')
-        local escaped_installer=$(echo "${TOOL_INSTALLERS[$i]}" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g')
-        local escaped_version=$(echo "${TOOL_VERSIONS[$i]}" | sed 's/"/\\"/g' | sed 's/\\/\\\\/g')
+        # Escape strings for JSON (backslashes first, then quotes)
+        local escaped_name=$(echo "${TOOL_NAMES[$i]}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+        local escaped_msg=$(echo "${TOOL_MESSAGES[$i]}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | tr -d '\n' | tr -d '\r')
+        local escaped_installer=$(echo "${TOOL_INSTALLERS[$i]}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+        local escaped_version=$(echo "${TOOL_VERSIONS[$i]}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
 
         tools_json+="${sep}\"${escaped_name}\": {\"tool\":\"${escaped_name}\",\"status\":\"${TOOL_STATUSES[$i]}\",\"installer\":\"${escaped_installer}\",\"version\":\"${escaped_version}\",\"message\":\"${escaped_msg}\",\"exit_code\":${TOOL_EXIT_CODES[$i]},\"timestamp\":\"${TOOL_TIMESTAMPS[$i]}\"}"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors setup.sh to track per-tool status/versions, emit PostHog events, improve error handling across installs, and upgrade `uv` via asdf.
> 
> - **Telemetry & Tracking**
>   - Add comprehensive per-tool tracking arrays (`TOOL_*`, `FAILED_TOOLS*`) with timestamps, installer, versions, and messages.
>   - Implement PostHog events: `setup:started`, `setup:finished` (with aggregated results), and `$exception` for individual failures.
>   - Cache latest script version lookup and include version info in analytics.
> - **Installation Flow & Messaging**
>   - Standardize `print_*` helpers to record results and failures; remove `DID_FAIL`.
>   - Enhance final summary with detailed failure list (tool, error, exit code, time).
> - **Setup Command**
>   - Improve alias management for `setup`; detect already-installed vs new.
>   - Download/upgrade `northslope-setup.sh` and record version; chmod handled.
> - **Package Managers**
>   - Brew: guided install, ensure `shellenv` in `.zshrc`, verify usability; record version and status with detailed error on failure.
>   - asdf: record install status/version; ensure PATH export in `.zshrc`.
> - **asdf Tool Installs**
>   - Add robust `asdf_install_and_set` with plugin/install/set error capture and already-installed detection.
>   - Bump `uv` from `0.9.7` to `1.9.7` in `asdf_tools`.
> - **Developer Tools & Auth**
>   - Cursor and Claude installs now record versions and already-installed state.
>   - `gh auth` flow records success/failure and version.
> - **Northslope Tools**
>   - `osdk-cli`: detect existing install, capture `npm` install errors, and record version/status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee16217f5cfa5f1d4afa33c90164ce9be435263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->