### PR TITLE
Correct uv version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -567,7 +567,7 @@ asdf_tools=(
     pnpm__10.20.0
     python__3.13.9
     github-cli__2.83.0
-    uv__1.9.7
+    uv__0.9.7
     jq__1.8.1
 )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `setup.sh` to install `uv` version `0.9.7` via asdf instead of `1.9.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c39ef814c5838897e4ed43e3c3d6499ec1b6a5de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->