### PR TITLE
Add java openjdk

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -569,6 +569,7 @@ asdf_tools=(
     github-cli__2.83.0
     uv__1.9.7
     jq__1.8.1
+    java__openjdk-17.0.2
 )
 
 for asdf_tool in ${asdf_tools[@]}; do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `java` (OpenJDK 17.0.2) to the asdf-managed tools in `setup.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d8a6ceb523feb3772649c3456d0308fc169989f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->