### PR TITLE
Enforce the home tool version setting

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -251,7 +251,13 @@ function emit_setup_finished_event {
 
 function check_home_version_set {
     local tool=$1
-    cat ${HOME}/.tool-versions | grep ${tool} > /dev/null 2>&1
+    local version=$2
+    tool_version=`cat ${HOME}/.tool-versions | grep ${tool} | cut -d' ' -f2`
+    if [[ "${tool_version}" == "${version}" ]]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 function asdf_install_and_set {
@@ -285,7 +291,7 @@ function asdf_install_and_set {
         return 1
     fi
 
-    check_home_version_set ${tool}
+    check_home_version_set ${tool} ${version}
     if [[ $? -ne 0 ]]; then
         # If a home version is not chosen
         # we choose the default version


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure `asdf` sets `--home` when the version in `~/.tool-versions` differs from the requested one.
> 
> - **Setup (`setup.sh`)**:
>   - Update `check_home_version_set` to accept `version` and compare against `~/.tool-versions`; returns success only on exact match.
>   - Update `asdf_install_and_set` to call `check_home_version_set ${tool} ${version}` and set `asdf set --home` when versions don’t match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3824429875cd3c584f4fb63b6dae546d712ed1c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->