### PR TITLE
Anchor the home tool-versions grep

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -252,7 +252,8 @@ function emit_setup_finished_event {
 function check_home_version_set {
     local tool=$1
     local version=$2
-    tool_version=`cat ${HOME}/.tool-versions | grep ${tool} | cut -d' ' -f2`
+    # Use anchored grep to match only lines starting with the tool name followed by a space
+    tool_version=`cat ${HOME}/.tool-versions | grep "^${tool} " | cut -d' ' -f2`
     if [[ "${tool_version}" == "${version}" ]]; then
         return 0
     else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Anchors grep in `check_home_version_set` to match exact tool names in `~/.tool-versions` (lines starting with `tool `).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c11e51abb8b3fcc9ddaf91cfc33c916e4fd39cbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->