### PR TITLE
Add direnv install to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -588,14 +588,23 @@ done
 asdf reshim
 
 # Set up direnv to be hooked into zsh
-cat ~/.zshrc | grep "eval \"(direnv hook zsh)\"" > /dev/null 2>&1
-DIRENV_ZSHRC_ALREADY_CONFIGURED=$?
-if [[ ${DIRENV_ZSHRC_ALREADY_CONFIGURED} -ne 0 ]]; then
-    echo "Adding direnv hook to .zshrc..."
-    echo 'eval "$(direnv hook zsh)"' >> $HOME/.zshrc
-    echo "Direnv hook added to .zshrc ✅"
+direnv version > /dev/null 2>&1
+DIRENV_INSTALLED_PROPERLY=$?
+
+if [[ ${DIRENV_INSTALLED_PROPERLY} -ne 0 ]]; then
+    echo "direnv command not available - cannot add hook"
 else
-    echo "Direnv hook already configured in .zshrc ✅"
+    # Check if hook is already configured
+    cat ~/.zshrc | grep "eval \"(direnv hook zsh)\"" > /dev/null 2>&1
+    DIRENV_ZSHRC_ALREADY_CONFIGURED=$?
+
+    if [[ ${DIRENV_ZSHRC_ALREADY_CONFIGURED} -ne 0 ]]; then
+        echo "direnv hook not configured - configuring..."
+        echo 'eval "$(direnv hook zsh)"' >> $HOME/.zshrc
+        echo "direnv hook configured ✅"
+    else
+        echo "direnv hook already configured ✅"
+    fi
 fi
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Gearing up to fix the [FOUNDRY_TOKEN](https://linear.app/northslope/issue/NOR-215/how-to-store-foundry-token) storage issue with direnv as part of the solution!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `direnv` installation to `setup.sh` via asdf and configures the zsh hook in `~/.zshrc` if missing.
> 
> - **Setup Script (`setup.sh`)**
>   - **Tools (asdf)**: Add `direnv__2.37.1` to `asdf_tools` and install with `asdf_install_and_set`.
>   - **Shell Integration**: After asdf installs, detect `direnv` and append `eval "$(direnv hook zsh)"` to `~/.zshrc` if not already present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1bb2e7133b89765658beec61843d92d44066997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->