### PR TITLE
Fix print and record errors

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -657,7 +657,6 @@ if [[ ${GH_AUTH_ALREADY_SET} -ne 0 ]]; then
     GH_VERSION=$(gh --version 2>/dev/null | head -1 | awk '{print $3}' || echo "")
     if [[ ${gh_auth_status} -eq 0 ]]; then
         echo "'gh auth' Authorized ✅"
-        record_tool_result "${TOOL}" "installed" "" "0" "system" "${GH_VERSION}"
         print_and_record_newly_installed_msg ${TOOL} ${GH_VERSION} "gh"
     else
         print_failed_install_msg "${TOOL}" "gh auth login failed or was interrupted" ${gh_auth_status} "system" "${GH_VERSION}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes setup logging by defaulting version arg, correctly recording CLAUDE version, and removing redundant gh auth record call.
> 
> - **Setup script (`setup.sh`)**:
>   - Make `print_and_record_newly_installed_msg` accept optional `version` (defaults to empty).
>   - Correct CLAUDE install logging to use `CLAUDE_VERSION` instead of `CURSOR_VERSION` for both installed/already-installed paths.
>   - Streamline `gh auth` success flow by removing redundant `record_tool_result` call and using `print_and_record_newly_installed_msg`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af7d6144a06fc272ef31980ce8a90df2d9eb276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->