### PR TITLE
Fix the setup version check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -377,6 +377,8 @@ if [[ ${SETUP_ALREADY_INSTALLED} -ne 0 ]]; then
     rm ${TEMP_ZSHRC}
     alias setup="${NORTHSLOPE_SETUP_SCRIPT_PATH}"
     chmod +x ${NORTHSLOPE_SETUP_SCRIPT_PATH}
+    curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/northslope-setup.sh > ${NORTHSLOPE_SETUP_SCRIPT_PATH}
+    get_latest_version > $NORTHSLOPE_SETUP_SCRIPT_VERSION_PATH
     print_and_record_newly_installed_msg ${TOOL}
 else
     IS_UPGRADING=1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes setup version detection and upgrade logic, downloading and recording the latest version when needed, and standardizes install status messages.
> 
> - **Setup command installation/upgrade**:
>   - Simplifies version check: set `IS_UPGRADING` default, compare `current_version` vs `get_latest_version`, and only download when out-of-date.
>   - On first-time install, download `northslope-setup.sh` and write `setup-version`.
>   - On upgrade, re-download script, update version file, and record as upgraded; otherwise record as already installed.
>   - Removes prior verbose version-check/branching (`SETUP_CMD_ALREADY_INSTALLED`, extra checks/messages).
> - **Messaging tweaks**:
>   - `print_and_record_already_installed_msg` prints "Installed ✅"; `print_and_record_newly_installed_msg` prints "Newly Installed ✨".
>   - `print_and_record_upgraded_msg` now requires explicit `version` arg (`local version=$2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe60f72961e17a981c2d7c94d9ff2005db27960e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->