### PR TITLE
Fix bad direnv message

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -604,7 +604,7 @@ else
         echo 'eval "$(direnv hook zsh)"' >> $HOME/.zshrc
         print_and_record_newly_installed_msg "${TOOL}"
     else
-        print_installed_msg "${TOOL}" false "manual" ""
+        print_and_record_already_installed_msg "${TOOL}"
     fi
 fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes direnv hook setup to correctly record the already-installed status using the unified logging function.
> 
> - **setup.sh**:
>   - **Direnv hook setup**: When the hook is already present, use `print_and_record_already_installed_msg "direnv hook"` instead of the old `print_installed_msg` to properly record the "already installed" status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bed5c9700a96ac411188d3d6cbec0d941738d79f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->