### PR TITLE
Update northslope script get_latest_version

### DIFF
--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -1,7 +1,12 @@
 #!/bin/zsh
 
+CACHED_LATEST_VERSION=""
+
 function get_latest_version {
-    curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | jq -r '.tag_name' | sed 's/\s//g' | sed 's/\n//g'
+    if [[ "${CACHED_LATEST_VERSION}" == "" ]]; then
+        CACHED_LATEST_VERSION=$(curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | grep tag_name | awk -F'"' '{ print $4 }' | sed 's/ //g')
+    fi
+    echo "${CACHED_LATEST_VERSION}"
 }
 
 function print_usage {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cache latest-version lookup in `northslope-setup.sh` and switch parsing from jq to grep/awk.
> 
> - **Script `northslope-setup.sh`**:
>   - **`get_latest_version`**:
>     - Add `CACHED_LATEST_VERSION` memoization to avoid repeated GitHub API calls.
>     - Replace `jq`-based JSON parsing with `grep`/`awk` + `sed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f18fce6548a08a92c06d7ded86d2af6e0c88ded. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->