### PR TITLE
Generate empty ns config json file on setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -323,9 +323,15 @@ function asdf_install_and_set {
 #------------------------------------------------------------------------------
 
 NORTHSLOPE_DIR=${HOME}/.northslope
+NORTHSLOPE_CONFIG_FILE=${NORTHSLOPE_DIR}/ns.config.json
 emit_setup_started_event &
 
 mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
+
+# Create empty ns.config.json if it doesn't exist
+if [[ ! -f ${NORTHSLOPE_CONFIG_FILE} ]]; then
+    echo "{}" > ${NORTHSLOPE_CONFIG_FILE}
+fi
 
 # Remove old versions of script and cache
 for f in ${HOME}/.northslope*; do


### PR DESCRIPTION
Adding this so that we can guarantee the user level `ns.config.json` file needed for [this](https://www.notion.so/RFC-Storing-Long-Lived-Foundry-Tokens-for-the-CLI-2b78a925f4278008812ac03351c4a02e) feature exists.

should make error handling within the CLI simpler! Simply direct users to run the setup script first and try again if `.northslope` or `.northslope/ns.config.json` don't exist for whatever reason🙂 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `~/.northslope/ns.config.json` is created (as `{}`) during setup if missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d218298767200f68f6f4dd02c9c21c67ba156c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->