### PR TITLE
initialize ns.config.json with expected schema

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -338,9 +338,14 @@ emit_setup_started_event &
 
 mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
 
-# Create empty ns.config.json if it doesn't exist
+# Create ns.config.json with default structure if it doesn't exist
 if [[ ! -f ${NORTHSLOPE_CONFIG_FILE} ]]; then
-    echo "{}" > ${NORTHSLOPE_CONFIG_FILE}
+    cat > ${NORTHSLOPE_CONFIG_FILE} << 'EOF'
+{
+  "auth": {
+  }
+}
+EOF
 fi
 
 # Remove old versions of script and cache


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Initialize `~/.northslope/ns.config.json` with a default `{ "auth": {} }` structure instead of an empty object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f78b0ba2561bbc4de3865eb928142c65164a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->