### PR TITLE
Restore .northslope/northslope-setup.sh on dir deletion

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -391,6 +391,7 @@ if [[ ${SETUP_ALIAS_EXISTS} -ne 0 ]]; then
     # cat used here in case .zshrc is symlinked
     cat ${TEMP_ZSHRC} > ${HOME}/.zshrc
     alias setup="${NORTHSLOPE_SETUP_SCRIPT_PATH}"
+    print_and_record_newly_installed_msg ${TOOL}
 fi
 
 function download_latest_setup_script {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors setup alias logic and adds explicit install/upgrade flow to download and version the `northslope-setup.sh` script when missing or outdated.
> 
> - **Setup script and alias**:
>   - Rename tool label to `setup alias` and adjust detection var (`SETUP_ALIAS_EXISTS`).
>   - Extract `download_latest_setup_script` helper to fetch, chmod, and write `setup-version`.
>   - Add separate install/upgrade flow for `setup script` that:
>     - Installs when script or `setup-version` is missing.
>     - Compares current vs. latest version to upgrade as needed.
>     - Includes version in status messages.
>   - Remove redundant chmod/curl inline calls and trailing chmod.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8804da003bc3a2cd364cc849922a68f423285410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->