### PR TITLE
delete ns config creation from setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -333,20 +333,9 @@ function asdf_install_and_set {
 #------------------------------------------------------------------------------
 
 NORTHSLOPE_DIR=${HOME}/.northslope
-NORTHSLOPE_CONFIG_FILE=${NORTHSLOPE_DIR}/ns.config.json
 emit_setup_started_event &
 
 mkdir -p $NORTHSLOPE_DIR > /dev/null 2>&1
-
-# Create ns.config.json with default structure if it doesn't exist
-if [[ ! -f ${NORTHSLOPE_CONFIG_FILE} ]]; then
-    cat > ${NORTHSLOPE_CONFIG_FILE} << 'EOF'
-{
-  "auth": {
-  }
-}
-EOF
-fi
 
 # Remove old versions of script and cache
 for f in ${HOME}/.northslope*; do


### PR DESCRIPTION
We only want to create the user level ns confing file from the NS CLI repository itself. That way, the source of truth for the initial structure of the user ns config file is ONLY found in the NS CLI repository, and not in this setup repository!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops defining NORTHSLOPE_CONFIG_FILE and removes automatic creation of ~/.northslope/ns.config.json during setup.
> 
> - **Setup script (`setup.sh`)**:
>   - **Initialization**:
>     - Remove `NORTHSLOPE_CONFIG_FILE` variable.
>     - Delete logic that creates default `~/.northslope/ns.config.json` if missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f99cc3feb1461ee65ea624c2374487b5b456f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->