### PR TITLE
Fix bad direnv grep

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -604,7 +604,7 @@ direnv --version > /dev/null 2>&1
 DIRENV_INSTALLED=$?
 print_check_msg "${TOOL}"
 
-cat ~/.zshrc | grep "eval \"$(direnv hook zsh)\"" > /dev/null 2>&1
+cat ~/.zshrc | grep 'eval "$(direnv hook zsh)"' > /dev/null 2>&1
 DIRENV_HOOK_IS_SETUP=$?
 
 if [[ ${DIRENV_INSTALLED} -ne 0 ]]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the grep pattern in `setup.sh` to correctly detect `eval "$(direnv hook zsh)"` in `~/.zshrc` using proper quoting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d1945c3e1bcec1e97d30f3ff7e2b056f67ca644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->