### PR TITLE
Fix bad tool reference

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -603,7 +603,7 @@ asdf_tools=(
 for asdf_tool in ${asdf_tools[@]}; do
     tool=${asdf_tool%__*}
     version=${asdf_tool#*__}
-    asdf_install_and_set "${TOOL}" ${version}
+    asdf_install_and_set "${tool}" ${version}
 done
 asdf reshim
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the asdf install loop to pass the lowercase `tool` variable to `asdf_install_and_set` instead of the undefined `TOOL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 531a11c3e862f3fb3f08b90eb66a84116f1b59bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->