### PR TITLE
Improve starship display

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -2,7 +2,7 @@
 
 # Custom format to include ns.config.json values
 format = """
-[┌─](bold green)$directory$git_branch$git_status${custom.impl_project_prefix}${custom.impl_name}${custom.project_name}
+[┌──](bold green) $directory$git_branch$git_status${custom.impl_project_prefix}${custom.impl_name}${custom.project_name}
 $character
 """
 
@@ -53,7 +53,7 @@ deleted = '[✘](bold red)'
 
 [character]
 success_symbol = '[└─>](bold green)'
-error_symbol = '[└─>](bold red)'
+error_symbol = '[└─✘](bold red)'
 
 [battery]
 full_symbol = "full "


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts starship prompt header formatting and changes the error symbol to ✘.
> 
> - **Starship prompt**:
>   - Update `format` to use `[┌──]` and add spacing before `$directory$git_branch$git_status...`.
>   - Change `character.error_symbol` from `[└─>]` to `[└─✘]` in bold red.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01328e0c9e46e95a0ccdf4bf34eae9302bd825d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->