### PR TITLE
Ensure tool versions exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -263,7 +263,8 @@ function check_home_version_set {
     local tool=$1
     local version=$2
     # Use anchored grep to match only lines starting with the tool name followed by a space
-    tool_version=`cat ${HOME}/.tool-versions | grep "^${tool} " | cut -d' ' -f2`
+    touch "${HOME}/.tool-versions"
+    tool_version=`cat "${HOME}/.tool-versions" | grep "^${tool} " | cut -d' ' -f2`
     if [[ "${tool_version}" == "${version}" ]]; then
         return 0
     else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure `~/.tool-versions` is created and path-quoted before parsing tool versions in `check_home_version_set`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5209ac309a94fb49d276b591868f265e43d4517a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->