### PR TITLE
Account for old --child flag

### DIFF
--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -93,7 +93,7 @@ case "$1" in
         print_usage
         exit 0
         ;;
-    --skip-update|skip)
+    --skip-update|--child|skip)
         SKIP_UPDATE=true
         shift
         ;;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for the legacy `--child` flag by treating it the same as `--skip-update` in `northslope-setup.sh`.
> 
> - **CLI flags**: In `northslope-setup.sh`, handle legacy `--child` flag by mapping it to `--skip-update` alongside existing `skip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84ab9ee273121f179d16a08688be8fedf2f3a803. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->