### PR TITLE
Add python and nodejs to starship

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -2,9 +2,12 @@
 
 # Custom format to include ns.config.json values
 format = """
-[┌──](bold green) $username $directory$git_branch$git_status${custom.impl_project_prefix}${custom.impl_name}${custom.project_name}
+[┌──](bold green) $username $directory$git_branch$git_status$nodejs$python${custom.impl_project_prefix}${custom.impl_name}${custom.project_name}
 $character
 """
+
+[python]
+format = '[${symbol}${pyenv_prefix}(${version} ) ]($style)'
 
 [custom.impl_project_prefix]
 when = '[ -f ns.config.json ]'
@@ -44,7 +47,7 @@ ignore_branches = []
 style = 'bold purple'
 
 [git_status]
-format = '($untracked$staged$conflicted$stashed$deleted$renamed$modified$ahead_behind)'
+format = '($untracked$staged$conflicted$stashed$deleted$renamed$modified$ahead_behind )'
 conflicted = '[⚔️${count}](bold red)'
 ahead = '[⇡${count}](bold cyan)'
 behind = '[⇣${count}](bold yellow)'
@@ -74,7 +77,8 @@ symbol = "erlang "
 symbol = "fortran "
 
 [nodejs]
-symbol = "node "
+format = '[$symbol ($version )]($style)'
+symbol = "JS"
 
 [pulumi]
 symbol = "pulumi "


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Python and Node.js info to the prompt (with versions) and tweaks git status spacing.
> 
> - **Starship prompt configuration (`starship.toml`)**:
>   - **Prompt format**: include `$nodejs` and `$python` in `format`.
>   - **Python module**: add `[python]` with custom `format` showing symbol and version.
>   - **Node.js module**: add `format` to display symbol and version; change `symbol` to `JS`.
>   - **Git status**: adjust `git_status.format` to include a trailing space inside parentheses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13880e20c5c84f041916ea35e10f032430b9ea95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->