### PR TITLE
Update setup script to use ns-cli and ns instead of osdk-cli

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -727,10 +727,10 @@ else
     echo "npm uninstall -g ns-cli" >> ${NS_CLI_INSTALL_LOG} 2>&1
     npm uninstall -g ns-cli >> ${NS_CLI_INSTALL_LOG} 2>&1
 
-    echo "asdf which ns-cli" >> ${NS_CLI_INSTALL_LOG} 2>&1
-    asdf which ns-cli >> ${NS_CLI_INSTALL_LOG} 2>&1
+    echo "asdf which ns" >> ${NS_CLI_INSTALL_LOG} 2>&1
+    asdf which ns >> ${NS_CLI_INSTALL_LOG} 2>&1
 
-    current_ns_cli_path=`asdf which ns-cli 2>/dev/null`
+    current_ns_cli_path=`asdf which ns 2>/dev/null`
     if [[ "${current_ns_cli_path}" != "" ]]; then
         echo "rm \"${current_ns_cli_path}\"" >> ${NS_CLI_INSTALL_LOG} 2>&1
         rm "${current_ns_cli_path}"  >> ${NS_CLI_INSTALL_LOG} 2>&1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces osdk-cli with ns-cli (ns) across setup, including branch arg, install/upgrade logic, repo paths, commands, and log filenames.
> 
> - **Northslope Tools**:
>   - Replace `osdk-cli` with `ns-cli` and CLI command `osdk-cli` with `ns`.
>   - Switch npm package from `@northslopetech/osdk-cli` to `@northslopetech/ns-cli`.
>   - Update local build/install flow: repo `northslopetech/ns-cli`, path `packages/ns-cli`, logs `ns-cli-install.log`, `asdf which ns`, uninstall `ns-cli`, and use `ns --version`.
>   - Adjust status messages to reference `ns-cli` and capture upgraded/newly installed versions accordingly.
> - **Initialization**:
>   - Rename branch arg/env from `OSDK_BRANCH` to `NS_CLI_BRANCH` and update related messages and git checkout steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e400976fdd1ca0f73bb85dc85a82ac6c5d99c2e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Resolves [NOR-339](https://linear.app/northslope/issue/NOR-339/update-setup-script-to-use-new-package-name)