### PR TITLE
Improve starship ns look

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -11,21 +11,21 @@ format = '[${symbol}${pyenv_prefix}(${version} ) ]($style)'
 
 [custom.impl_project_prefix]
 when = '[ -f ns.config.json ]'
-format = "\n[│]($style)"
+format = "\n[├── ns: ]($style)"
 style = 'bold green'
 
 # Custom module to display implName
 [custom.impl_name]
 command = 'jq -r ".implName // empty" ns.config.json 2>/dev/null'
 when = '[ -f ns.config.json ]'
-format = '[ impl: $output ]($style)'
+format = '[$output ]($style)'
 style = 'bold cyan'
 
 # Custom module to display projectName
 [custom.project_name]
 command = 'jq -r ".projectName // empty" ns.config.json 2>/dev/null'
 when = '[ -f ns.config.json ]'
-format = "[ project: $output ]($style)"
+format = "[$output ]($style)"
 style = 'bold yellow'
 
 [username]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines Starship prompt for ns.config.json: adds "ns:" prefix and drops "impl:"/"project:" labels.
> 
> - **Starship prompt (starship.toml)**:
>   - `custom.impl_project_prefix`: change format from `│` to `├── ns:`.
>   - `custom.impl_name`: remove `impl:` label, now just `[$output ]`.
>   - `custom.project_name`: remove `project:` label, now just `[$output ]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78dcd12964399f95fa160f35a1ea495f68d634e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->