### PR TITLE
Increase default starship command timeout

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -1,5 +1,8 @@
 "$schema" = 'https://starship.rs/config-schema.json'
 
+# Increase global command timeout to 1000ms (1 second)
+command_timeout = 1000
+
 # Custom format to include ns.config.json values
 format = """
 [┌──](bold green) $username $directory$git_branch$git_status$nodejs$python${custom.impl_project_prefix}${custom.impl_name}${custom.project_name}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase Starship global command timeout to 1000ms in `starship.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5f5a1fb58f3c5ac090156149829cd5e0cf294bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->