### PR TITLE
Add permissions checks

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -357,7 +357,7 @@ if [[ ! -d "$NORTHSLOPE_DIR" ]]; then
 else
     # Directory exists, try to chown to verify permissions
     chown "$USER" "$NORTHSLOPE_DIR" 2>/dev/null
-    if [[ $? -ne 0 ]] && [[ ! -w "$NORTHSLOPE_DIR" ]]; then
+    if [[ $? -ne 0 ]] || [[ ! -w "$NORTHSLOPE_DIR" ]]; then
         PERMISSION_ERRORS+=("No write permission for directory: $NORTHSLOPE_DIR")
         BAD_PERMISSION_PATHS+=("$NORTHSLOPE_DIR")
     fi
@@ -374,7 +374,7 @@ for file in "${FILES_TO_CHECK[@]}"; do
     if [[ -e "$file" ]]; then
         # File exists, try to chown to verify permissions
         chown "$USER" "$file" 2>/dev/null
-        if [[ $? -ne 0 ]] && [[ ! -w "$file" ]]; then
+        if [[ $? -ne 0 ]] || [[ ! -w "$file" ]]; then
             PERMISSION_ERRORS+=("No write permission for file: $file")
             BAD_PERMISSION_PATHS+=("$file")
         fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a preflight permissions check in `setup.sh` that validates write access to `~/.northslope`, shell RC files, and `~/.gitconfig`, failing early with guidance if issues are found.
> 
> - **Setup Script (`setup.sh`)**:
>   - **Preflight permissions check**:
>     - Validates write access to `~/.northslope`, `~/.bashrc`, `~/.zshrc`, and `~/.gitconfig` (creates files if missing).
>     - Attempts `chown`/`touch` to verify; aggregates errors and exits with actionable `sudo chown $USER <path>` guidance.
>     - Integrates with existing result tracking via `print_failed_install_msg` and `print_and_record_already_installed_msg`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9c0cd1ae8512b8246f2d20c8f259054760a6bda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->