### PR TITLE
Refactor the brew install function

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -576,7 +576,7 @@ fi
 
 
 brew_tools=(
-    "asdf__2"
+    "asdf__3"
     "autojump__2"
     "fzf__1"
     "starship__2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors setup.sh to use a generic brew_install_tool helper and a tool list to install multiple brew tools (incl. claude cask), reducing duplicated logic and standardizing version reporting.
> 
> - **setup.sh**
>   - **Brew install refactor**:
>     - Add `get_tool_version` and `brew_install_tool` helpers with standardized version extraction.
>     - Replace repetitive blocks with `brew_tools` array + loop for `asdf`, `autojump`, `fzf`, `starship`, `tree`.
>     - Switch `claude` install to `brew_install_tool` with `--cask` and package `claude-code`.
>   - **Env**:
>     - Export ASDF shims path after brew installations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e492c79c337172e7f64074829e528887e65f0f7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->