### PR TITLE
Add asdf plugin veracity check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -341,6 +341,12 @@ function asdf_install_and_set {
     plugin_output=$(asdf plugin add ${tool} 2>&1)
     plugin_status=$?
 
+    # Check if plugin add was successful
+    if [[ ${plugin_status} -ne 0 ]]; then
+        print_failed_install_msg "${tool} ${version}" "asdf install failed: ${plugin_output}" ${plugin_status} "asdf" "${version}"
+        return 1
+    fi
+
     # No-op if command is installed
     install_output=$(asdf install ${tool} ${version} 2>&1)
     install_status=$?


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds explicit error handling after `asdf plugin add` to record and abort when the plugin add step fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f10ec18883a2dd69ac913a7dc65cc03aa65736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->