### PR TITLE
Add time and command duration

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -23,7 +23,7 @@ format = " [$time]($style)"
 min_time = 1_000
 show_milliseconds = false
 format = " [$duration]($style)"
-style = "bold yellow"
+style = "bold green"
 
 [python]
 format = '[${symbol}${pyenv_prefix}(${version} ) ]($style)'


### PR DESCRIPTION
<img width="424" height="167" alt="image" src="https://github.com/user-attachments/assets/e0cbf043-2b98-47b5-a6e2-29a3b1fffac8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Starship prompt to display command duration and current time, adding fill for alignment.
> 
> - **Shell prompt (`starship.toml`)**:
>   - **Format update**: Insert `$fill`, `$cmd_duration`, and `$time` into the main prompt before git info.
>   - **New modules**:
>     - `fill`: space symbol, no style.
>     - `time`: enabled with `%H:%M:%S`, dim white, custom format.
>     - `cmd_duration`: min 1000ms, bold green, custom format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e1312bf88e2a4553393b5254c324283ed6dabd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->