### PR TITLE
Add missing java home

### DIFF
--- a/northslope-base-shell.rc
+++ b/northslope-base-shell.rc
@@ -87,8 +87,7 @@ eval $(/opt/homebrew/bin/brew shellenv)
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # Source java home
-source ~/.asdf/plugins/java/set-java-home.${CURRENT_SHELL}
-
+source ${HOME}/.asdf/plugins/java/set-java-home.${CURRENT_SHELL}
 
 # direnv
 eval "$(direnv hook $CURRENT_SHELL)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sources the asdf Java plugin script to correctly set JAVA_HOME in the shell initialization.
> 
> - **Shell config**:
>   - Source asdf Java plugin script `~/${HOME#/}/.asdf/plugins/java/set-java-home.${CURRENT_SHELL}` in `northslope-base-shell.rc` to set `JAVA_HOME` for the active shell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43bb51369a75e0906a557e189027f1978e2fb009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->