### PR TITLE
Fix config backwards incompatibility

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -732,7 +732,7 @@ fi
 # This is overwritable by the user
 TOOL="git config pull.rebase"
 print_check_msg ${TOOL}
-git config get --global pull.rebase > /dev/null 2>&1
+git config --global pull.rebase > /dev/null 2>&1
 GIT_PULL_REBASE_ALREADY_SET=$?
 if [[ ${GIT_PULL_REBASE_ALREADY_SET} -ne 0 ]]; then
     print_missing_msg ${TOOL}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the setup script works with older Git versions by avoiding the `git config get` subcommand.
> 
> - In `setup.sh`, change the pull.rebase check from `git config get --global pull.rebase` to `git config --global pull.rebase` to prevent errors during Git config detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665a822ef7b073aa94ece4e2e754fc3f37d10842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->