### PR TITLE
Add timeout installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -673,6 +673,26 @@ for brew_tool in ${brew_tools[@]}; do
     brew_install_tool "${tool}" ${version_index}
 done
 
+# Install coreutils if timeout command doesn't exist
+TOOL=timeout
+print_check_msg ${TOOL}
+timeout --version > /dev/null 2>&1
+timeout_exists=$?
+if [[ ${timeout_exists} -ne 0 ]]; then
+    print_missing_msg ${TOOL}
+    brew install coreutils
+    COREUTILS_VERSION=$(brew list --versions coreutils 2>/dev/null | awk '{print $2}' || echo "")
+    print_and_record_newly_installed_msg "coreutils" "${COREUTILS_VERSION}" "brew"
+else
+    # timeout exists, check if it's from coreutils
+    COREUTILS_VERSION=$(brew list --versions coreutils 2>/dev/null | awk '{print $2}' || echo "")
+    if [[ -n "${COREUTILS_VERSION}" ]]; then
+        print_and_record_already_installed_msg "coreutils" "${COREUTILS_VERSION}" "brew"
+    else
+        print_and_record_already_installed_msg "${TOOL}" "" "system"
+    fi
+fi
+
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a post-brew step in `setup.sh` to ensure `timeout` is available.
> 
> - Checks for `timeout`; if missing, installs `coreutils` via Homebrew and records the installed version
> - If `timeout` exists, reports `coreutils` as already installed when applicable; otherwise records `timeout` as provided by the system
> - Uses existing `print_*` helpers to consistently log and track installation status
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50430aa782ad52f41ffb9de79b851a109b9814a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->