### PR TITLE
feature: add northslope claude marketplace to setup script [NOR-448]

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1047,19 +1047,19 @@ else
     cd - > /dev/null 2>&1
 fi
 
-# Install northslope claude-code-resources marketplace
-TOOL="claude marketplace northslope-claude-resources"
+# Install northslope claude-marketplace
+TOOL="claude marketplace northslope-claude-marketplace"
 print_check_msg "${TOOL}"
 
 # Check if marketplace is already installed
-claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-code-resources" > /dev/null 2>&1
+claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-marketplace" > /dev/null 2>&1
 MARKETPLACE_ALREADY_INSTALLED=$?
 
 # Use SSH or HTTPS URL based on detected git protocol
 if [[ "${GIT_PROTOCOL}" == "ssh" ]]; then
-    MARKETPLACE_URL="git@github.com:northslopetech/claude-code-resources.git"
+    MARKETPLACE_URL="git@github.com:northslopetech/claude-marketplace.git"
 else
-    MARKETPLACE_URL="https://github.com/northslopetech/claude-code-resources"
+    MARKETPLACE_URL="https://github.com/northslopetech/claude-marketplace"
 fi
 
 if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
@@ -1073,13 +1073,13 @@ if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
     fi
 else
     # Update the marketplace to ensure it's current
-    update_output=$(claude plugin marketplace update northslope-claude-resources 2>&1)
+    update_output=$(claude plugin marketplace update northslope-claude-marketplace 2>&1)
     update_status=$?
     if [[ ${update_status} -eq 0 ]]; then
         print_and_record_already_installed_msg "${TOOL}" "" "claude"
     else
         # Update failed, likely due to old branch reference - remove and re-add
-        claude plugin marketplace remove northslope-claude-resources > /dev/null 2>&1
+        claude plugin marketplace remove northslope-claude-marketplace > /dev/null 2>&1
         add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
         add_status=$?
         if [[ ${add_status} -eq 0 ]]; then
@@ -1095,8 +1095,8 @@ MARKETPLACE_CONFIG="${HOME}/.claude/plugins/known_marketplaces.json"
 if [[ -f "${MARKETPLACE_CONFIG}" ]]; then
     # Check if jq is available
     if command -v jq > /dev/null 2>&1; then
-        # Enable auto-update for northslope-claude-resources
-        jq '.["northslope-claude-resources"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
+        # Enable auto-update for northslope-claude-marketplace
+        jq '.["northslope-claude-marketplace"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
         if [[ $? -eq 0 ]] && [[ -s "${MARKETPLACE_CONFIG}.tmp" ]]; then
             mv "${MARKETPLACE_CONFIG}.tmp" "${MARKETPLACE_CONFIG}"
         else

--- a/setup.sh
+++ b/setup.sh
@@ -895,6 +895,34 @@ else
     print_and_record_already_installed_msg "${TOOL}" "" "gh"
 fi
 
+# Install northslope claude-code-resources marketplace
+TOOL="claude marketplace northslope-claude-resources"
+print_check_msg "${TOOL}"
+
+# Check if marketplace is already installed
+claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-code-resources" > /dev/null 2>&1
+MARKETPLACE_ALREADY_INSTALLED=$?
+
+if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
+    print_missing_msg "${TOOL}"
+    add_output=$(claude plugin marketplace add https://github.com/northslopetech/claude-code-resources 2>&1)
+    add_status=$?
+    if [[ ${add_status} -eq 0 ]]; then
+        print_and_record_newly_installed_msg "${TOOL}" "main" "claude"
+    else
+        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" "main"
+    fi
+else
+    # Update the marketplace to ensure it's current
+    update_output=$(claude plugin marketplace update northslope-claude-resources 2>&1)
+    update_status=$?
+    if [[ ${update_status} -eq 0 ]]; then
+        print_and_record_already_installed_msg "${TOOL}" "main" "claude"
+    else
+        print_failed_install_msg "${TOOL}" "Failed to update marketplace: ${update_output}" ${update_status} "claude" "main"
+    fi
+fi
+
 #------------------------------------------------------------------------------
 # Northslope Tools
 #------------------------------------------------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -895,58 +895,6 @@ else
     print_and_record_already_installed_msg "${TOOL}" "" "gh"
 fi
 
-# Install northslope claude-code-resources marketplace
-TOOL="claude marketplace northslope-claude-resources"
-print_check_msg "${TOOL}"
-
-# Check if marketplace is already installed
-claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-code-resources" > /dev/null 2>&1
-MARKETPLACE_ALREADY_INSTALLED=$?
-
-if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
-    print_missing_msg "${TOOL}"
-    add_output=$(claude plugin marketplace add https://github.com/northslopetech/claude-code-resources 2>&1)
-    add_status=$?
-    if [[ ${add_status} -eq 0 ]]; then
-        print_and_record_newly_installed_msg "${TOOL}" "main" "claude"
-    else
-        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" "main"
-    fi
-else
-    # Update the marketplace to ensure it's current
-    update_output=$(claude plugin marketplace update northslope-claude-resources 2>&1)
-    update_status=$?
-    if [[ ${update_status} -eq 0 ]]; then
-        print_and_record_already_installed_msg "${TOOL}" "main" "claude"
-    else
-        # Update failed, likely due to old branch reference - remove and re-add
-        claude plugin marketplace remove northslope-claude-resources > /dev/null 2>&1
-        add_output=$(claude plugin marketplace add https://github.com/northslopetech/claude-code-resources 2>&1)
-        add_status=$?
-        if [[ ${add_status} -eq 0 ]]; then
-            print_and_record_already_installed_msg "${TOOL}" "main" "claude"
-        else
-            print_failed_install_msg "${TOOL}" "Failed to re-add marketplace after update failure: ${add_output}" ${add_status} "claude" "main"
-        fi
-    fi
-fi
-
-# Enable auto-update for the marketplace
-MARKETPLACE_CONFIG="${HOME}/.claude/plugins/known_marketplaces.json"
-if [[ -f "${MARKETPLACE_CONFIG}" ]]; then
-    # Check if jq is available
-    if command -v jq > /dev/null 2>&1; then
-        # Enable auto-update for northslope-claude-resources
-        jq '.["northslope-claude-resources"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
-        if [[ $? -eq 0 ]] && [[ -s "${MARKETPLACE_CONFIG}.tmp" ]]; then
-            mv "${MARKETPLACE_CONFIG}.tmp" "${MARKETPLACE_CONFIG}"
-        else
-            rm -f "${MARKETPLACE_CONFIG}.tmp"
-            echo "   ⚠️  Could not enable auto-update for marketplace (non-fatal)"
-        fi
-    fi
-fi
-
 #------------------------------------------------------------------------------
 # Northslope Tools
 #------------------------------------------------------------------------------
@@ -1090,6 +1038,57 @@ else
     cd - > /dev/null 2>&1
 fi
 
+# Install northslope claude-code-resources marketplace
+TOOL="claude marketplace northslope-claude-resources"
+print_check_msg "${TOOL}"
+
+# Check if marketplace is already installed
+claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-code-resources" > /dev/null 2>&1
+MARKETPLACE_ALREADY_INSTALLED=$?
+
+if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
+    print_missing_msg "${TOOL}"
+    add_output=$(claude plugin marketplace add https://github.com/northslopetech/claude-code-resources 2>&1)
+    add_status=$?
+    if [[ ${add_status} -eq 0 ]]; then
+        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
+    else
+        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
+    fi
+else
+    # Update the marketplace to ensure it's current
+    update_output=$(claude plugin marketplace update northslope-claude-resources 2>&1)
+    update_status=$?
+    if [[ ${update_status} -eq 0 ]]; then
+        print_and_record_already_installed_msg "${TOOL}" "" "claude"
+    else
+        # Update failed, likely due to old branch reference - remove and re-add
+        claude plugin marketplace remove northslope-claude-resources > /dev/null 2>&1
+        add_output=$(claude plugin marketplace add https://github.com/northslopetech/claude-code-resources 2>&1)
+        add_status=$?
+        if [[ ${add_status} -eq 0 ]]; then
+            print_and_record_already_installed_msg "${TOOL}" "" "claude"
+        else
+            print_failed_install_msg "${TOOL}" "Failed to re-add marketplace after update failure: ${add_output}" ${add_status} "claude" ""
+        fi
+    fi
+fi
+
+# Enable auto-update for the marketplace
+MARKETPLACE_CONFIG="${HOME}/.claude/plugins/known_marketplaces.json"
+if [[ -f "${MARKETPLACE_CONFIG}" ]]; then
+    # Check if jq is available
+    if command -v jq > /dev/null 2>&1; then
+        # Enable auto-update for northslope-claude-resources
+        jq '.["northslope-claude-resources"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
+        if [[ $? -eq 0 ]] && [[ -s "${MARKETPLACE_CONFIG}.tmp" ]]; then
+            mv "${MARKETPLACE_CONFIG}.tmp" "${MARKETPLACE_CONFIG}"
+        else
+            rm -f "${MARKETPLACE_CONFIG}.tmp"
+            echo "   ⚠️  Could not enable auto-update for marketplace (non-fatal)"
+        fi
+    fi
+fi
 
 #------------------------------------------------------------------------------
 # Finalization

--- a/setup.sh
+++ b/setup.sh
@@ -1052,14 +1052,14 @@ TOOL="claude marketplace northslope-claude-marketplace"
 print_check_msg "${TOOL}"
 
 # Check if marketplace is already installed
-claude plugin marketplace list 2>/dev/null | grep "northslopetech/claude-marketplace" > /dev/null 2>&1
+claude plugin marketplace list 2>/dev/null | grep "northslopetech/northslope-claude-marketplace" > /dev/null 2>&1
 MARKETPLACE_ALREADY_INSTALLED=$?
 
 # Use SSH or HTTPS URL based on detected git protocol
 if [[ "${GIT_PROTOCOL}" == "ssh" ]]; then
-    MARKETPLACE_URL="git@github.com:northslopetech/claude-marketplace.git"
+    MARKETPLACE_URL="git@github.com:northslopetech/northslope-claude-marketplace.git"
 else
-    MARKETPLACE_URL="https://github.com/northslopetech/claude-marketplace"
+    MARKETPLACE_URL="https://github.com/northslopetech/northslope-claude-marketplace"
 fi
 
 if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -867,9 +867,9 @@ else
     print_and_record_already_installed_msg "${TOOL}" ${GH_VERSION} "gh"
 fi
 
-# Detect git protocol and export GITHUB_TOKEN if using SSH
+# Detect git protocol and export GITHUB_TOKEN if using HTTPS
 GIT_PROTOCOL=$(gh config get git_protocol 2>/dev/null || echo "https")
-if [[ "${GIT_PROTOCOL}" == "ssh" ]]; then
+if [[ "${GIT_PROTOCOL}" == "https" ]]; then
     export GITHUB_TOKEN=$(gh auth token 2>/dev/null)
     if [[ -z "${GITHUB_TOKEN}" ]]; then
         echo "⚠️  Warning: Failed to get GitHub token. Claude marketplace may not work properly."

--- a/setup.sh
+++ b/setup.sh
@@ -1059,19 +1059,10 @@ MARKETPLACE_ALREADY_INSTALLED=$?
 if [[ "${GIT_PROTOCOL}" == "ssh" ]]; then
     MARKETPLACE_URL="git@github.com:northslopetech/northslope-claude-marketplace.git"
 else
-    MARKETPLACE_URL="https://github.com/northslopetech/northslope-claude-marketplace"
+    MARKETPLACE_URL="https://github.com/northslopetech/northslope-claude-marketplace.git"
 fi
 
-if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
-    print_missing_msg "${TOOL}"
-    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
-    add_status=$?
-    if [[ ${add_status} -eq 0 ]]; then
-        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
-    else
-        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
-    fi
-else
+if [[ ${MARKETPLACE_ALREADY_INSTALLED} -eq 0 ]]; then
     # Update the marketplace to ensure it's current
     update_output=$(claude plugin marketplace update northslope-claude-marketplace 2>&1)
     update_status=$?
@@ -1087,6 +1078,15 @@ else
         else
             print_failed_install_msg "${TOOL}" "Failed to re-add marketplace after update failure: ${add_output}" ${add_status} "claude" ""
         fi
+    fi
+else
+    print_missing_msg "${TOOL}"
+    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
+    add_status=$?
+    if [[ ${add_status} -eq 0 ]]; then
+        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
+    else
+        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1062,12 +1062,26 @@ else
     MARKETPLACE_URL="https://github.com/northslopetech/northslope-claude-marketplace.git"
 fi
 
-if [[ ${MARKETPLACE_ALREADY_INSTALLED} -eq 0 ]]; then
+# Track if marketplace installation/update succeeded
+MARKETPLACE_SUCCESS=0
+
+if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
+    print_missing_msg "${TOOL}"
+    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
+    add_status=$?
+    if [[ ${add_status} -eq 0 ]]; then
+        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
+        MARKETPLACE_SUCCESS=1
+    else
+        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
+    fi
+else
     # Update the marketplace to ensure it's current
     update_output=$(claude plugin marketplace update northslope-claude-marketplace 2>&1)
     update_status=$?
     if [[ ${update_status} -eq 0 ]]; then
         print_and_record_already_installed_msg "${TOOL}" "" "claude"
+        MARKETPLACE_SUCCESS=1
     else
         # Update failed, likely due to old branch reference - remove and re-add
         claude plugin marketplace remove northslope-claude-marketplace > /dev/null 2>&1
@@ -1075,33 +1089,27 @@ if [[ ${MARKETPLACE_ALREADY_INSTALLED} -eq 0 ]]; then
         add_status=$?
         if [[ ${add_status} -eq 0 ]]; then
             print_and_record_already_installed_msg "${TOOL}" "" "claude"
+            MARKETPLACE_SUCCESS=1
         else
             print_failed_install_msg "${TOOL}" "Failed to re-add marketplace after update failure: ${add_output}" ${add_status} "claude" ""
         fi
     fi
-else
-    print_missing_msg "${TOOL}"
-    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
-    add_status=$?
-    if [[ ${add_status} -eq 0 ]]; then
-        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
-    else
-        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
-    fi
 fi
 
-# Enable auto-update for the marketplace
-MARKETPLACE_CONFIG="${HOME}/.claude/plugins/known_marketplaces.json"
-if [[ -f "${MARKETPLACE_CONFIG}" ]]; then
-    # Check if jq is available
-    if command -v jq > /dev/null 2>&1; then
-        # Enable auto-update for northslope-claude-marketplace
-        jq '.["northslope-claude-marketplace"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
-        if [[ $? -eq 0 ]] && [[ -s "${MARKETPLACE_CONFIG}.tmp" ]]; then
-            mv "${MARKETPLACE_CONFIG}.tmp" "${MARKETPLACE_CONFIG}"
-        else
-            rm -f "${MARKETPLACE_CONFIG}.tmp"
-            echo "   ⚠️  Could not enable auto-update for marketplace (non-fatal)"
+# Enable auto-update for the marketplace (only if installation/update succeeded)
+if [[ ${MARKETPLACE_SUCCESS} -eq 1 ]]; then
+    MARKETPLACE_CONFIG="${HOME}/.claude/plugins/known_marketplaces.json"
+    if [[ -f "${MARKETPLACE_CONFIG}" ]]; then
+        # Check if jq is available
+        if command -v jq > /dev/null 2>&1; then
+            # Enable auto-update for northslope-claude-marketplace
+            jq '.["northslope-claude-marketplace"].autoUpdate = true' "${MARKETPLACE_CONFIG}" > "${MARKETPLACE_CONFIG}.tmp" 2>/dev/null
+            if [[ $? -eq 0 ]] && [[ -s "${MARKETPLACE_CONFIG}.tmp" ]]; then
+                mv "${MARKETPLACE_CONFIG}.tmp" "${MARKETPLACE_CONFIG}"
+            else
+                rm -f "${MARKETPLACE_CONFIG}.tmp"
+                echo "   ⚠️  Could not enable auto-update for marketplace (non-fatal)"
+            fi
         fi
     fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1115,6 +1115,9 @@ if [[ ${MARKETPLACE_SUCCESS} -eq 1 ]]; then
                 echo "   ⚠️  Could not enable auto-update for marketplace (non-fatal)"
             fi
         fi
+    fi
+fi
+
 #------------------------------------------------------------------------------
 # NS CLI Upgrade Checker Crontab
 #------------------------------------------------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -1069,17 +1069,7 @@ fi
 # Track if marketplace installation/update succeeded
 MARKETPLACE_SUCCESS=0
 
-if [[ ${MARKETPLACE_ALREADY_INSTALLED} -ne 0 ]]; then
-    print_missing_msg "${TOOL}"
-    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
-    add_status=$?
-    if [[ ${add_status} -eq 0 ]]; then
-        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
-        MARKETPLACE_SUCCESS=1
-    else
-        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
-    fi
-else
+if [[ ${MARKETPLACE_ALREADY_INSTALLED} -eq 0 ]]; then
     # Update the marketplace to ensure it's current
     update_output=$(claude plugin marketplace update northslope-claude-marketplace 2>&1)
     update_status=$?
@@ -1097,6 +1087,16 @@ else
         else
             print_failed_install_msg "${TOOL}" "Failed to re-add marketplace after update failure: ${add_output}" ${add_status} "claude" ""
         fi
+    fi
+else
+    print_missing_msg "${TOOL}"
+    add_output=$(claude plugin marketplace add ${MARKETPLACE_URL} 2>&1)
+    add_status=$?
+    if [[ ${add_status} -eq 0 ]]; then
+        print_and_record_newly_installed_msg "${TOOL}" "" "claude"
+        MARKETPLACE_SUCCESS=1
+    else
+        print_failed_install_msg "${TOOL}" "Failed to add marketplace: ${add_output}" ${add_status} "claude" ""
     fi
 fi
 


### PR DESCRIPTION
Setup script adds [northslope's claude code plugins ](https://github.com/northslopetech/claude-code-resources/) so FDEs can import shared plugins

open question: 
* do we want to enable all plugins? I think no, because we want to be selective re: which plugins to enable vs not enable depending on the project that an FDE is working on. 

<img width="1046" height="644" alt="image" src="https://github.com/user-attachments/assets/81ca51e5-6079-4dd8-b6da-64ed23c26324" />

<img width="537" height="338" alt="image" src="https://github.com/user-attachments/assets/76602e1c-e995-4c20-9cf0-f85d6f56c845" />
