### PR TITLE
Update org setup url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Run the following command
 
 ```
-/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh)"
+/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslope-tech/setup/refs/heads/latest/setup.sh)"
 ```
 
 ## After

--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -56,7 +56,7 @@ CACHED_LATEST_VERSION=""
 
 function get_latest_version {
     if [[ "${CACHED_LATEST_VERSION}" == "" ]]; then
-        CACHED_LATEST_VERSION=$(curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | grep tag_name | awk -F'"' '{ print $4 }' | sed 's/ //g')
+        CACHED_LATEST_VERSION=$(curl -sL https://api.github.com/repos/northslope-tech/setup/releases/latest | grep tag_name | awk -F'"' '{ print $4 }' | sed 's/ //g')
     fi
     echo "${CACHED_LATEST_VERSION}"
 }
@@ -102,7 +102,7 @@ esac
 # Always download the latest version unless explicitly skipped
 if [[ -z "${SKIP_UPDATE}" ]]; then
     # Download the new northslope-setup.sh
-    curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/northslope-setup.sh -o "${NORTHSLOPE_NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
+    curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslope-tech/setup/refs/heads/latest/northslope-setup.sh -o "${NORTHSLOPE_NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
     curl_exit_code=$?
     if [[ ${curl_exit_code} -ne 0 ]]; then
         error_msg="Failed to download updated northslope-setup.sh: ${curl_output}"
@@ -120,7 +120,7 @@ fi
 echo "Running 'setup' version $(get_local_version)"
 
 # Create a setup script so that we can pass in command line args
-curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh -o "${NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
+curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslope-tech/setup/refs/heads/latest/setup.sh -o "${NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
 curl_exit_code=$?
 if [[ ${curl_exit_code} -ne 0 ]]; then
     error_msg="Failed to download setup.sh: ${curl_output}"

--- a/setup.sh
+++ b/setup.sh
@@ -53,7 +53,7 @@ CACHED_LATEST_VERSION=""
 
 function get_latest_version {
     if [[ "${CACHED_LATEST_VERSION}" == "" ]]; then
-        CACHED_LATEST_VERSION=$(curl -sL https://api.github.com/repos/northslopetech/setup/releases/latest | grep tag_name | awk -F'"' '{ print $4 }' | sed 's/ //g')
+        CACHED_LATEST_VERSION=$(curl -sL https://api.github.com/repos/northslope-tech/setup/releases/latest | grep tag_name | awk -F'"' '{ print $4 }' | sed 's/ //g')
     fi
     echo "${CACHED_LATEST_VERSION}"
 }
@@ -572,7 +572,7 @@ function download_latest_shell {
     pids=()
     for northslope_downloadable_path in "${NORTHSLOPE_DOWNLOADABLE_PATHS[@]}"; do
         filename=$(basename ${northslope_downloadable_path})
-        url=https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/${filename}
+        url=https://raw.githubusercontent.com/northslope-tech/setup/refs/heads/latest/${filename}
         curl -fsSL ${url} > ${northslope_downloadable_path} &
         pids+=($!)
     done
@@ -894,26 +894,26 @@ if [[ "${GIT_PROTOCOL}" == "https" ]]; then
 fi
 
 # Ensure a part of the northslopetech organization
-TOOL="github northslopetech org"
+TOOL="github northslope-tech org"
 print_check_msg "${TOOL}"
-gh org list | grep northslopetech > /dev/null 2>&1
+gh org list | grep northslope-tech > /dev/null 2>&1
 GH_IN_NORTHSLOPE_ORG=$?
 if [[ ${GH_IN_NORTHSLOPE_ORG} -ne 0 ]]; then
     print_missing_msg "${TOOL}"
     echo ""
-    echo "⚠️ You are not a member of the northslopetech organization on Github."
+    echo "⚠️ You are not a member of the northslope-tech organization on Github."
     echo "   If you do not have an invitation, please contact Tam Nguyen (@tnguyen) to be added to the organization."
     echo "   Press enter to check if you have an invitation for the organization. Return here when you have accepted it."
     read
-    open 'https://github.com/orgs/northslopetech/invitation'
+    open 'https://github.com/orgs/northslope-tech/invitation'
     echo  ""
     echo "   Press enter to continue setup after accepting the invitation (or not)."
     echo "   If you did not have an invitation, please contact Tam Nguyen (@tnguyen) to be added to the organization."
     read
-    gh org list | grep northslopetech > /dev/null 2>&1
+    gh org list | grep northslope-tech > /dev/null 2>&1
     GH_IN_NORTHSLOPE_ORG=$?
     if [[ ${GH_IN_NORTHSLOPE_ORG} -ne 0 ]]; then
-        print_failed_install_msg "${TOOL}" "Not a member of northslopetech organization" 1 "gh" ""
+        print_failed_install_msg "${TOOL}" "Not a member of northslope-tech organization" 1 "gh" ""
     else
         print_and_record_newly_installed_msg "${TOOL}" "" "gh"
     fi
@@ -991,8 +991,8 @@ else
 
     # Clone repository if it doesn't exist
     if [[ ! -e ${LOCAL_NS_CLI_DIR} ]]; then
-        echo "$ gh repo clone northslopetech/ns-cli ${LOCAL_NS_CLI_DIR}" >> ${NS_CLI_INSTALL_LOG}
-        gh repo clone northslopetech/ns-cli ${LOCAL_NS_CLI_DIR} >> ${NS_CLI_INSTALL_LOG} 2>&1
+        echo "$ gh repo clone northslope-tech/ns-cli ${LOCAL_NS_CLI_DIR}" >> ${NS_CLI_INSTALL_LOG}
+        gh repo clone northslope-tech/ns-cli ${LOCAL_NS_CLI_DIR} >> ${NS_CLI_INSTALL_LOG} 2>&1
         if [[ $? -ne 0 ]]; then
             should_install=0
             failed_step="gh repo clone"
@@ -1071,14 +1071,14 @@ TOOL="claude marketplace northslope-claude-marketplace"
 print_check_msg "${TOOL}"
 
 # Check if marketplace is already installed
-claude plugin marketplace list 2>/dev/null | grep "northslopetech/northslope-claude-marketplace" > /dev/null 2>&1
+claude plugin marketplace list 2>/dev/null | grep "northslope-tech/northslope-claude-marketplace" > /dev/null 2>&1
 MARKETPLACE_ALREADY_INSTALLED=$?
 
 # Use SSH or HTTPS URL based on detected git protocol
 if [[ "${GIT_PROTOCOL}" == "ssh" ]]; then
-    MARKETPLACE_URL="git@github.com:northslopetech/northslope-claude-marketplace.git"
+    MARKETPLACE_URL="git@github.com:northslope-tech/northslope-claude-marketplace.git"
 else
-    MARKETPLACE_URL="https://github.com/northslopetech/northslope-claude-marketplace.git"
+    MARKETPLACE_URL="https://github.com/northslope-tech/northslope-claude-marketplace.git"
 fi
 
 # Track if marketplace installation/update succeeded


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> String/URL updates only; primary risk is breaking setup downloads or GitHub org checks if any endpoint was missed or the new org name is incorrect.
> 
> **Overview**
> Updates the setup entrypoints and scripts to use the `northslope-tech` GitHub org name instead of `northslopetech`.
> 
> This changes the README install command, release-version lookup (`api.github.com/repos/.../releases/latest`), raw script download URLs, GitHub org membership check + invitation link, and repo/plugin references (e.g., `gh repo clone` for `ns-cli` and Claude marketplace URLs) to point at the new org.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6994498048cc136555a013cfe79cb769a0d7a1d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->