### PR TITLE
Migrate setup script to northslope dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Run the following command
 
 ```
-/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh)"
+/bin/zsh -c "$(curl -fsSL https://setup.northslope.dev)"
 ```
 
 ## After

--- a/northslope-setup.sh
+++ b/northslope-setup.sh
@@ -102,7 +102,7 @@ esac
 # Always download the latest version unless explicitly skipped
 if [[ -z "${SKIP_UPDATE}" ]]; then
     # Download the new northslope-setup.sh
-    curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/northslope-setup.sh -o "${NORTHSLOPE_NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
+    curl_output=$(curl -fsSL https://setup.northslope.dev -o "${NORTHSLOPE_NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
     curl_exit_code=$?
     if [[ ${curl_exit_code} -ne 0 ]]; then
         error_msg="Failed to download updated northslope-setup.sh: ${curl_output}"
@@ -120,7 +120,7 @@ fi
 echo "Running 'setup' version $(get_local_version)"
 
 # Create a setup script so that we can pass in command line args
-curl_output=$(curl -fsSL https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/setup.sh -o "${NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
+curl_output=$(curl -fsSL https://setup.northslope.dev -o "${NORTHSLOPE_SETUP_SCRIPT_PATH}" 2>&1)
 curl_exit_code=$?
 if [[ ${curl_exit_code} -ne 0 ]]; then
     error_msg="Failed to download setup.sh: ${curl_output}"

--- a/setup.sh
+++ b/setup.sh
@@ -572,7 +572,7 @@ function download_latest_shell {
     pids=()
     for northslope_downloadable_path in "${NORTHSLOPE_DOWNLOADABLE_PATHS[@]}"; do
         filename=$(basename ${northslope_downloadable_path})
-        url=https://raw.githubusercontent.com/northslopetech/setup/refs/heads/latest/${filename}
+        url=https://setup.northslope.dev/${filename}
         curl -fsSL ${url} > ${northslope_downloadable_path} &
         pids+=($!)
     done


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the bootstrap/update download URLs for the setup flow, so any misconfiguration or outage of the new host could break installs and self-updates. No core installation logic changes beyond the fetch endpoints.
> 
> **Overview**
> Migrates the setup entrypoint to use `https://setup.northslope.dev` instead of GitHub `raw.githubusercontent.com` URLs.
> 
> `README.md`, `northslope-setup.sh`, and `setup.sh` now fetch the main scripts and auxiliary shell assets from the new domain (including per-file downloads via `setup.northslope.dev/<filename>`), keeping the rest of the execution flow the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55bff8dcfa3d5b0f6362cc6d028eb732b6aff850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->